### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 My precious .vim files
 
-##Install
+## Install
 First, install [homesick](https://github.com/technicalpickles/homesick). Then 
 
     $ homesick clone jridgewell/dotvim


### PR DESCRIPTION
`Install` doesn't render as a heading without the space.